### PR TITLE
Suppress output of secret-derived data

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -10,6 +10,7 @@
 - name: Retrieve SSH private key from Hashicorp Vault
   set_fact:
     ssh_key_json: "{{ lookup('community.hashi_vault.hashi_vault', hashicorp_vault_private_key_path)  }}"
+  no_log: true
 
 - name: Ensure SSH directory exists
   file:
@@ -27,3 +28,4 @@
     owner: "{{ ssh_key_owner  }}"
     group: "{{ ssh_key_group }}"
     mode: '{{ ssh_key_mode }}'
+  no_log: true


### PR DESCRIPTION
This change adds `no_log: true` to tasks that handle secret values to prevent accidental disclosure in Ansible output. This reduces the risk of sensitive values being exposed in CI/CD logs or playbook output if a task encounters an error or is executed with increased verbosity.

Resolves: `CWE-532`.